### PR TITLE
Don't add create_schema to schema.rb

### DIFF
--- a/lib/apartment.rb
+++ b/lib/apartment.rb
@@ -21,6 +21,10 @@ if ActiveRecord.version.release >= Gem::Version.new('7.0')
   require_relative 'apartment/active_record/enum_patch'
 end
 
+if ActiveRecord.version.release >= Gem::Version.new('7.1')
+  require_relative 'apartment/active_record/postgres/schema_dumper'
+end
+
 # Apartment main definitions
 module Apartment
   class << self

--- a/lib/apartment/active_record/postgres/schema_dumper.rb
+++ b/lib/apartment/active_record/postgres/schema_dumper.rb
@@ -1,0 +1,9 @@
+# This patch prevents `create_schema` from being added to db/schema.rb as schemas are managed by Apartment
+# not ActiveRecord like they would be in a vanilla Rails setup.
+
+require "active_record/connection_adapters/postgresql/schema_dumper"
+
+class ActiveRecord::ConnectionAdapters::PostgreSQL::SchemaDumper
+  def schemas(stream)
+  end
+end


### PR DESCRIPTION
This patch prevents `create_schema` from being added to db/schema.rb as schemas are managed by Apartment not ActiveRecord like they would be in a vanilla Rails setup.

https://www.pivotaltracker.com/story/show/186354303